### PR TITLE
Update cmake version requirement to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.10)
 
 # Remove git hash from version number if present
 string(REGEX REPLACE "([0-9.]+).*" "\\1" VERSION "${VERSION}")

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,30 @@
+BSD 3-Clause License
+
+Copyright (c) 2014-2020 Jolla Ltd.
+Copyright (c) 2025 Jolla Mobile Ltd.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+

--- a/rpm/libsystrace.spec
+++ b/rpm/libsystrace.spec
@@ -2,8 +2,8 @@ Name: libsystrace
 Version: 0.0.0
 Release: 1
 Summary: A library for logging systrace data
-License: BSD
-URL: https://git.sailfishos.org/mer-core/libsystrace
+License: BSD-3-Clause
+URL: https://github.com/sailfishos/libsystrace
 Source0: %{name}-%{version}.tar.bz2
 BuildRequires: cmake
 Requires(post): /sbin/ldconfig
@@ -23,31 +23,23 @@ Requires: %{name} = %{version}-%{release}
 %setup -q -n %{name}-%{version}
 
 %build
-mkdir -p build
-pushd build
-%cmake .. \
+%cmake \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX=%{_prefix} \
     -DVERSION=%{version}
-make %{?_smp_mflags}
-popd
+%cmake_build
 
 %install
-rm -rf %{buildroot}
-make -C build install DESTDIR=%{buildroot}
-
-%clean
-rm -rf %{buildroot}
-
-%files
-%defattr(-,root,root,-)
-%{_libdir}/libsystrace.so.*
-
-%files devel
-%defattr(-,root,root,-)
-%{_libdir}/libsystrace.so
-%{_libdir}/pkgconfig/systrace.pc
-%{_includedir}/systrace.h
+%cmake_install
 
 %post -p /sbin/ldconfig
 %postun -p /sbin/ldconfig
+
+%files
+%license LICENSE.md
+%{_libdir}/libsystrace.so.*
+
+%files devel
+%{_libdir}/libsystrace.so
+%{_libdir}/pkgconfig/systrace.pc
+%{_includedir}/systrace.h


### PR DESCRIPTION
Fixes build with cmake 4. Use cmake macros.
Update URL. Add missing license file.